### PR TITLE
remove rstrip as it can strip valid characters from password f…

### DIFF
--- a/pass-filter.py
+++ b/pass-filter.py
@@ -17,8 +17,7 @@ def list_passwords():
 
     for root, dirnames, filenames in os.walk(PASS_DIR):
         for filename in fnmatch.filter(filenames, '*.gpg'):
-            ret.append(os.path.join(root, filename).rstrip('.gpg').replace(PASS_DIR, ''))
-
+            ret.append(os.path.join(root, filename.replace('.gpg','')).replace(PASS_DIR, ''))
     return sorted(ret, key=lambda s: s.lower())
 
 


### PR DESCRIPTION
Example.

Password in file "andy/testgroup"

Before this change
`./pass-filter.py testgrou`
Output:

```
<?xml version="1.0"?>
<items>

    <item uid="andy/testgrou" arg="andy/testgrou" autocomplete="andy/testgrou">
        <title>testgrou</title>
        <subtitle>andy/testgrou</subtitle>
    </item>

</items>
```

After change
`./pass-filter.py testgrou`
Output:

```
<?xml version="1.0"?>
<items>

    <item uid="andy/testgroup" arg="andy/testgroup" autocomplete="andy/testgroup">
        <title>testgroup</title>
        <subtitle>andy/testgroup</subtitle>
    </item>

</items>
```

Notice the 'p' at the end of "group" is being stripped. This is due to the use of rstrip.
