### PR TITLE
Placed quotes around $QUERY

### DIFF
--- a/pass-show.sh
+++ b/pass-show.sh
@@ -14,5 +14,5 @@ else
 fi
 
 # PASS
-#pass show $QUERY | awk 'BEGIN{ORS=""} {print; exit}' | pbcopy
-pass show -c $QUERY
+#pass show "$QUERY" | awk 'BEGIN{ORS=""} {print; exit}' | pbcopy
+pass show -c "$QUERY"


### PR DESCRIPTION
This fixes a bug when searching for secrets with whitespaces in their
name.