### PR TITLE
Add feature to copy the username

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ See [Keep a CHANGELOG](http://keepachangelog.com/) for more details.
 
 ## [Unreleased]
 
+## [0.3.4] - 2018-08-29
+### Added
+- copy username to clipboard
+
 ## [0.3.3] - 2018-06-18
 ### Added
 - Notify when password is copied to clipboard

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ pass show $QUERY | awk 'BEGIN{ORS=""} {print; exit}' | pbcopy
 
 to aviod auto-clearing of clipboard.
 
+If you press and hold the alt key, the username is copied instead of the password.  
+
 ## `pg <id>`
 Calls `pass generate` to add a new password with default length of 20 chars.
 

--- a/info.plist
+++ b/info.plist
@@ -20,6 +20,16 @@
 				<key>vitoclose</key>
 				<false/>
 			</dict>
+			<dict>
+				<key>destinationuid</key>
+				<string>6E5D5164-B37E-4492-86A3-00C72B9425C6</string>
+				<key>modifiers</key>
+				<integer>524288</integer>
+				<key>modifiersubtext</key>
+				<string>Copy username</string>
+				<key>vitoclose</key>
+				<false/>
+			</dict>
 		</array>
 		<key>97122574-1811-40EE-8FA3-CA5A7E8CB809</key>
 		<array>
@@ -123,6 +133,29 @@
 				<key>escaping</key>
 				<integer>102</integer>
 				<key>script</key>
+				<string>bash login-show.sh "{query}"</string>
+				<key>scriptargtype</key>
+				<integer>0</integer>
+				<key>scriptfile</key>
+				<string></string>
+				<key>type</key>
+				<integer>0</integer>
+			</dict>
+			<key>type</key>
+			<string>alfred.workflow.action.script</string>
+			<key>uid</key>
+			<string>6E5D5164-B37E-4492-86A3-00C72B9425C6</string>
+			<key>version</key>
+			<integer>2</integer>
+		</dict>
+		<dict>
+			<key>config</key>
+			<dict>
+				<key>concurrently</key>
+				<false/>
+				<key>escaping</key>
+				<integer>102</integer>
+				<key>script</key>
 				<string>bash pass-generate.sh "{query}"</string>
 				<key>scriptargtype</key>
 				<integer>0</integer>
@@ -176,7 +209,14 @@
 			<key>xpos</key>
 			<integer>500</integer>
 			<key>ypos</key>
-			<real>180</real>
+			<integer>340</integer>
+		</dict>
+		<key>6E5D5164-B37E-4492-86A3-00C72B9425C6</key>
+		<dict>
+			<key>xpos</key>
+			<integer>500</integer>
+			<key>ypos</key>
+			<integer>200</integer>
 		</dict>
 		<key>7DD3BDE5-A157-42E5-9376-F681FB50A4EE</key>
 		<dict>
@@ -190,7 +230,7 @@
 			<key>xpos</key>
 			<integer>300</integer>
 			<key>ypos</key>
-			<real>180</real>
+			<integer>340</integer>
 		</dict>
 	</dict>
 	<key>version</key>

--- a/login-show.sh
+++ b/login-show.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+QUERY=$1
+PATH=/usr/local/bin:$PATH
+
+pass show "$QUERY" | /usr/bin/sed -E -n '/login|user/p' | /usr/bin/sed -E -e 's/(login: |user: )*//' | pbcopy
+osascript -e 'display notification "Copied username to clipboard" with title "Unix pass"'


### PR DESCRIPTION
Sometimes it's needed to copy the username before the password.

If you press and hold the alt key, the username is copied instead of the password.