### PR TITLE
Add M1 homebrew to PATH

### DIFF
--- a/pass-show.sh
+++ b/pass-show.sh
@@ -3,7 +3,7 @@
 set -e
 
 QUERY=$1
-PATH=/usr/local/bin:$PATH
+PATH=/opt/homebrew/bin/:/usr/local/bin:$PATH
 
 # GPG agent
 #envfile="$HOME/.gnupg/gpg-agent.env"


### PR DESCRIPTION
Add alternative homebrew path to find `pass` on M1 chipped macs.