### PR TITLE
Add new Homebrew Path

### DIFF
--- a/pass-show.sh
+++ b/pass-show.sh
@@ -3,7 +3,7 @@
 set -e
 
 QUERY=$1
-PATH=/usr/local/bin:$PATH
+PATH=/usr/local/bin:/opt/homebrew/bin:$PATH
 
 # GPG agent
 #envfile="$HOME/.gnupg/gpg-agent.env"


### PR DESCRIPTION
On the newest Mac Version the homebrew path has changed, i guess because of m1 chips or something like that. Adding the new path and everything works again.