### PR TITLE
Support MacOS 12

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -95,7 +95,7 @@
 				<key>runningsubtext</key>
 				<string></string>
 				<key>script</key>
-				<string>/usr/local/bin/python3 pass-filter.py  "{query}"</string>
+				<string>python3 pass-filter.py  "{query}"</string>
 				<key>scriptargtype</key>
 				<integer>0</integer>
 				<key>scriptfile</key>

--- a/info.plist
+++ b/info.plist
@@ -95,7 +95,7 @@
 				<key>runningsubtext</key>
 				<string></string>
 				<key>script</key>
-				<string>python pass-filter.py "{query}"</string>
+				<string>/usr/local/bin/python3 pass-filter.py  "{query}"</string>
 				<key>scriptargtype</key>
 				<integer>0</integer>
 				<key>scriptfile</key>


### PR DESCRIPTION
MacOS 12 removes support for python (2.7) and no longer ships any
python.
In order properly support newer MacOS releases pass workflow should
reuse python manually installed (ideally via brew)